### PR TITLE
Limits

### DIFF
--- a/Scans/Motion.py
+++ b/Scans/Motion.py
@@ -30,14 +30,19 @@ class Motion(object):
     5
 
     """
-    def __init__(self, getter, setter, title):
+    def __init__(self, getter, setter, title, low=None, high=None):
         self.getter = getter
         self.setter = setter
         self.title = title
+        self._low = low
+        self._high = high
 
     def __call__(self, x=None):
         if x is None:
             return self.getter()
+        reach, msg = self.accessible(x)
+        if not reach:
+            raise RuntimeError(msg)
         return self.setter(x)
 
     def __iadd__(self, x):
@@ -55,6 +60,51 @@ class Motion(object):
     def __repr__(self):
         return "{} is at {}".format(self.title, self())
 
+    def accessible(self, x):
+        """Determines whether a motor can reach the desired position.
+
+        Parameters
+        ==========
+        x
+          The desired position for the motor
+
+        Returns
+        =======
+
+        Tuple (Bool, Str)
+
+        The boolean represents whether the possition can be reached
+        The string is an error message explaining why the position is
+        unreachable.
+
+        """
+        if self.low is not None and x < self.low:
+            return (False,
+                    "Position {} is below lower limit {} of motor {}".format(
+                        x, self.low, self.title))
+        if self.high is not None and x > self.high:
+            return (False,
+                    "Position {} is above upper limit {} of motor {}".format(
+                        x, self.high, self.title))
+        return (True, "Position is Accessible")
+
+    @property
+    def low(self):
+        """The motion's lower limit"""
+        return self._low
+
+    @low.setter
+    def low(self, x):
+        self._low = x
+
+    @property
+    def high(self):
+        """The motion's uppder limit"""
+        return self._high
+
+    @high.setter
+    def high(self, x):
+        self._high = x
 
 class BlockMotion(Motion):
     """

--- a/Scans/Motion.py
+++ b/Scans/Motion.py
@@ -114,6 +114,7 @@ class Motion(object):
     def high(self, x):
         self._high = x
 
+
 class BlockMotion(Motion):
     """
 

--- a/Scans/Motion.py
+++ b/Scans/Motion.py
@@ -40,9 +40,7 @@ class Motion(object):
     def __call__(self, x=None):
         if x is None:
             return self.getter()
-        reach, msg = self.accessible(x)
-        if not reach:
-            raise RuntimeError(msg)
+        self.require(x)
         return self.setter(x)
 
     def __iadd__(self, x):
@@ -87,6 +85,16 @@ class Motion(object):
                     "Position {} is above upper limit {} of motor {}".format(
                         x, self.high, self.title))
         return (True, "Position is Accessible")
+
+    def require(self, x):
+        """Requires that the given position is accessible.  If not, an
+        exception is thrown
+
+        """
+        success, msg = self.accessible(x)
+        if success:
+            return
+        raise RuntimeError(msg)
 
     @property
     def low(self):

--- a/Scans/Util.py
+++ b/Scans/Util.py
@@ -115,6 +115,11 @@ def make_scan(defaults):
         """
         points = get_points(motion(), **kwargs)
 
+        for point in points:
+            success, msg = motion.accessible(point)
+            if not success:
+                raise RuntimeError(msg)
+
         return SimpleScan(motion, points, defaults)
     return scan
 

--- a/Scans/Util.py
+++ b/Scans/Util.py
@@ -116,9 +116,7 @@ def make_scan(defaults):
         points = get_points(motion(), **kwargs)
 
         for point in points:
-            success, msg = motion.accessible(point)
-            if not success:
-                raise RuntimeError(msg)
+            motion.require(point)
 
         return SimpleScan(motion, points, defaults)
     return scan

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -165,6 +165,17 @@ Plot Motor Scan
   Taking a count at theta=3.50 and two theta=0.00
   Taking a count at theta=4.00 and two theta=0.00
 
+  Soft limits can be placed on motors with the `low` and `high`
+  properties.  Scans that attempt to exceed these values will throw an
+  error.
+
+  >>> THETA.high = 2
+  >>> scan(THETA, start=0, stop=10, count=21)
+  Traceback (most recent call last):
+      ...
+  RuntimeError: Position 2.5 is above upper limit 2 of motor theta
+  >>> THETA.high = None
+
 Perform Fits
 ------------
 


### PR DESCRIPTION
This adds soft limits to the motor objects, as requested in issue #8.  The limits are checked when the scan is initially created and again when the motor is moved.  It is *not* checked with the scan is started, so there can be a problem if the limits are changed between the scan's creation and the scan's start.

The motor will still not attempt to move to the illegal position, but the user will not be warned of their mistake until that particular point in the scan, instead of at the beginning, as originally desired.