### PR TITLE
Give warning about false error message

### DIFF
--- a/Scans/multiplot.py
+++ b/Scans/multiplot.py
@@ -2,6 +2,7 @@
 """A demo of proper multiprocessing matplotlib"""
 from __future__ import print_function
 from multiprocessing import Process, Pipe
+from logging import warning
 import sys
 import threading
 import numpy as np
@@ -86,6 +87,9 @@ class NBPlot(object):
     """
     def __init__(self, **kwargs):
         self.plot_pipe, plotter_pipe = Pipe()
+        warning("Python will soon give an Error message about get_block_names."
+                " Please ignore that error message.  Everything is working as"
+                " expected.")
         self.plotter = ProcessPlotter(**kwargs)
         self.plot_process = Process(target=self.plotter,
                                     args=(plotter_pipe,))


### PR DESCRIPTION
We can't stop genie_python from giving that error message when launching a child process, but maybe we can inform the user that everything is okay?